### PR TITLE
[#71] Align license headers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Hits-of-Code](https://hitsofcode.com/github/arsysop/svn?branch=main)](https://hitsofcode.com/githubarsysop/svn?branch=main/view?branch=main)
 
 ###### License 
-Copyright © 2023, 2024 ArSysOp and others
+Copyright ï¿½ 2023, 2025 ArSysOp and others
 
 [![Apache License 2.0](https://img.shields.io/badge/Apache--2.0-thistle.svg)](https://github.com/arsysop/svn/blob/main/LICENSE) 
 

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/OSGI-INF/l10n/bundle.properties
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/build.properties
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/build.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/plugin.xml
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/RepositoryDateFormat.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/RepositoryDateFormat.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.adapt;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnNullableAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnNullableAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnNullableArray.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnNullableArray.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.adapt;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnNullableConstructor.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnNullableConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnTypeAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnTypeConstructor.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnTypeConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnTypeMap.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/SvnTypeMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ChangePathAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ChangePathAdapter.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.adapt.jhlsv;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ChecksumNullableAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ChecksumNullableAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ChoiceAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ChoiceAdapter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, 2025 ArSysOp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ */
+
+package ru.arsysop.svn.connector.internal.adapt.jhlsv;
+
+import org.apache.subversion.javahl.ConflictResult.Choice;
+import org.eclipse.team.svn.core.connector.SVNConflictResolution;
+
+import ru.arsysop.svn.connector.internal.adapt.SvnNullableConstructor;
+
+public final class ChoiceAdapter extends SvnNullableConstructor<Choice, SVNConflictResolution.Choice> {
+
+	public ChoiceAdapter(Choice choice) {
+		super(choice);
+	}
+
+	@Override
+	protected SVNConflictResolution.Choice adapt(org.apache.subversion.javahl.ConflictResult.Choice choice) {
+		if (choice == org.apache.subversion.javahl.ConflictResult.Choice.chooseBase) {
+			return SVNConflictResolution.Choice.CHOOSE_BASE;
+		}
+		if (choice == org.apache.subversion.javahl.ConflictResult.Choice.chooseTheirsFull) {
+			return SVNConflictResolution.Choice.CHOOSE_REMOTE_FULL;
+		}
+		if (choice == org.apache.subversion.javahl.ConflictResult.Choice.chooseMineFull) {
+			return SVNConflictResolution.Choice.CHOOSE_LOCAL_FULL;
+		}
+		if (choice == org.apache.subversion.javahl.ConflictResult.Choice.chooseTheirsConflict) {
+			return SVNConflictResolution.Choice.CHOOSE_REMOTE;
+		}
+		if (choice == org.apache.subversion.javahl.ConflictResult.Choice.chooseMineConflict) {
+			return SVNConflictResolution.Choice.CHOOSE_LOCAL;
+		}
+		if (choice == org.apache.subversion.javahl.ConflictResult.Choice.chooseMerged) {
+			return SVNConflictResolution.Choice.CHOOSE_MERGED;
+		}
+		return SVNConflictResolution.Choice.POSTPONE;
+	}
+
+}

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ClientNotifyInformationActionAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ClientNotifyInformationActionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ClientNotifyInformationAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ClientNotifyInformationAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ClientNotifyInformationStatusAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ClientNotifyInformationStatusAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ConflictDescriptorNullableAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ConflictDescriptorNullableAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ConflictVersionNullableAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ConflictVersionNullableAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/DepthAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/DepthAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/InfoNullableAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/InfoNullableAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/LockNullableAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/LockNullableAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/LockStatusAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/LockStatusAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/MergeInfoAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/MergeInfoAdapter.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.adapt.jhlsv;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/NodeActionAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/NodeActionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/NodeKindAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/NodeKindAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ReposNotifyInformationActionAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ReposNotifyInformationActionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ReposNotifyInformationAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/ReposNotifyInformationAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/RevPropertyConverter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/RevPropertyConverter.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.adapt.jhlsv;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/RevisionAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/RevisionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/RevisionRangeAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/RevisionRangeAdapter.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.adapt.jhlsv;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/StatusKindAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/StatusKindAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/TristateAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/TristateAdapter.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.adapt.jhlsv;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/TypeStatusAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/jhlsv/TypeStatusAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/AdaptClientNotifyCallback.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/AdaptClientNotifyCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/AdaptMessageReceiver.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/AdaptMessageReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/AdaptReposNotifyCallback.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/AdaptReposNotifyCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/ChoiceAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/ChoiceAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, 2025 ArSysOp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ */
+
+package ru.arsysop.svn.connector.internal.adapt.svjhl;
+
+import org.apache.subversion.javahl.ConflictResult.Choice;
+import org.eclipse.team.svn.core.connector.SVNConflictResolution;
+
+import ru.arsysop.svn.connector.internal.adapt.SvnNullableConstructor;
+
+public final class ChoiceAdapter extends SvnNullableConstructor<SVNConflictResolution.Choice, Choice> {
+
+	public ChoiceAdapter(SVNConflictResolution.Choice choice) {
+		super(choice);
+	}
+
+	@Override
+	protected Choice adapt(SVNConflictResolution.Choice choice) {
+		switch (choice) {
+			case CHOOSE_BASE:
+				return org.apache.subversion.javahl.ConflictResult.Choice.chooseBase;
+			case CHOOSE_REMOTE_FULL:
+				return org.apache.subversion.javahl.ConflictResult.Choice.chooseTheirsFull;
+			case CHOOSE_LOCAL_FULL:
+				return org.apache.subversion.javahl.ConflictResult.Choice.chooseMineFull;
+			case CHOOSE_REMOTE:
+				return org.apache.subversion.javahl.ConflictResult.Choice.chooseTheirsConflict;
+			case CHOOSE_LOCAL:
+				return org.apache.subversion.javahl.ConflictResult.Choice.chooseMineConflict;
+			case CHOOSE_MERGED:
+				return org.apache.subversion.javahl.ConflictResult.Choice.chooseMerged;
+			default:
+		}
+		return org.apache.subversion.javahl.ConflictResult.Choice.postpone;
+	}
+
+}

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/DepthAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/DepthAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/InfoCallbackAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/InfoCallbackAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/InheritedCallbackAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/InheritedCallbackAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/LogKindAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/LogKindAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/PropertyCallbackAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/PropertyCallbackAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/PropertyCallbackPair.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/PropertyCallbackPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/ReposFreezeActionNullableAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/ReposFreezeActionNullableAdapter.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2024
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.adapt.svjhl;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/RevisionAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/RevisionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/RevisionRangeAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/RevisionRangeAdapter.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.adapt.svjhl;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/StatusCallbackAdapter.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/adapt/svjhl/StatusCallbackAdapter.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.adapt.svjhl;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CallWatch.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CallWatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/Cancel.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/Cancel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommandCallback.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommandCallback.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.svnkit1_10;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommandFast.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommandFast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommandLong.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommandLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommandSafe.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommandSafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommitMessage.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommitMessage.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.svnkit1_10;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommitStatusCallback.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CommitStatusCallback.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.svnkit1_10;
@@ -39,7 +41,7 @@ final class CommitStatusCallback implements org.apache.subversion.javahl.callbac
 				info.getReposRoot(), //
 				info.getRevision(), //
 				info.getDate() != null ? info.getDate().getTime() : 0, //
-				info.getAuthor()//
-		));
+						info.getAuthor()//
+				));
 	}
 }

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CredentialsCallback.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/CredentialsCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/ProgressCallback.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/ProgressCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/QueryFast.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/QueryFast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/QueryLong.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/QueryLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/QuerySafe.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/QuerySafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/RevProps.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/RevProps.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) ArSysOp 2020-2025
- * 
- * ArSysOp and its affiliates make no warranty of any kind
- * with regard to this material.
- * 
- * ArSysOp expressly disclaims all warranties as to the material, express,
- * and implied, including but not limited to the implied warranties of
- * merchantability, fitness for a particular purpose and non-infringement of third
- * party rights.
- * 
- * In no event shall ArSysOp be liable to you or any other person for any damages,
- * including, without limitation, any direct, indirect, incidental or consequential
- * damages, expenses, lost profits, lost data or other damages arising out of the use,
- * misuse or inability to use the material and any derived software, even if ArSysOp,
- * its affiliate or an authorized dealer has been advised of the possibility of such damages.
+ * Copyright (c) 2023, 2025 ArSysOp
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
  */
 
 package ru.arsysop.svn.connector.internal.svnkit1_10;

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/SvnKit1_10Connector.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/SvnKit1_10Connector.java
@@ -71,6 +71,7 @@ import ru.arsysop.svn.connector.internal.adapt.jhlsv.LockNullableAdapter;
 import ru.arsysop.svn.connector.internal.adapt.jhlsv.MergeInfoAdapter;
 import ru.arsysop.svn.connector.internal.adapt.jhlsv.NodeKindAdapter;
 import ru.arsysop.svn.connector.internal.adapt.svjhl.AdaptClientNotifyCallback;
+import ru.arsysop.svn.connector.internal.adapt.svjhl.ChoiceAdapter;
 import ru.arsysop.svn.connector.internal.adapt.svjhl.DepthAdapter;
 import ru.arsysop.svn.connector.internal.adapt.svjhl.InfoCallbackAdapter;
 import ru.arsysop.svn.connector.internal.adapt.svjhl.InheritedCallbackAdapter;
@@ -543,8 +544,18 @@ final class SvnKit1_10Connector implements ISVNConnector {
 	@Override
 	public void resolve(String path, Choice conflictResult, SVNDepth depth, ISVNProgressMonitor monitor)
 			throws SVNConnectorException {
-		System.out.println("SvnKit1_10Connector.resolve()");
-		//TODO
+		Map<String, Object> parameters = new HashMap<>();
+		parameters.put("path", path);
+		parameters.put("conflictResult", conflictResult);
+		parameters.put("depth", depth);
+		parameters.put("monitor", monitor);
+		watch.commandLong(ISVNCallListener.RESOLVE, //
+				parameters, //
+				callback(monitor), //
+				p -> client.resolve(//
+						path, //
+						new DepthAdapter(depth).adapt(), //
+						new ChoiceAdapter(conflictResult).adapt()));
 	}
 
 	@Override

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/SvnKit1_10ConnectorFactory.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/SvnKit1_10ConnectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/SvnKit1_10Manager.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/SvnKit1_10Manager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/Watchdog.java
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/src/ru/arsysop/svn/connector/internal/svnkit1_10/Watchdog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/features/ru.arsysop.svn.connectors.svnkit1_10.feature/build.properties
+++ b/features/ru.arsysop.svn.connectors.svnkit1_10.feature/build.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/features/ru.arsysop.svn.connectors.svnkit1_10.feature/feature.properties
+++ b/features/ru.arsysop.svn.connectors.svnkit1_10.feature/feature.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/features/ru.arsysop.svn.connectors.svnkit1_10.feature/feature.xml
+++ b/features/ru.arsysop.svn.connectors.svnkit1_10.feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/features/ru.arsysop.svn.license.feature/build.properties
+++ b/features/ru.arsysop.svn.license.feature/build.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/features/ru.arsysop.svn.license.feature/feature.properties
+++ b/features/ru.arsysop.svn.license.feature/feature.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/features/ru.arsysop.svn.license.feature/feature.xml
+++ b/features/ru.arsysop.svn.license.feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/releng/ru.arsysop.svn.aggregator/pom.xml
+++ b/releng/ru.arsysop.svn.aggregator/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/releng/ru.arsysop.svn.parent/pom.xml
+++ b/releng/ru.arsysop.svn.parent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/releng/ru.arsysop.svn.releng/compositeArtifacts.xml
+++ b/releng/ru.arsysop.svn.releng/compositeArtifacts.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <?compositeMetadataRepository version='1.0.0'?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/releng/ru.arsysop.svn.releng/compositeContent.xml
+++ b/releng/ru.arsysop.svn.releng/compositeContent.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <?compositeArtifactRepository version='1.0.0'?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/releng/ru.arsysop.svn.repository/category.xml
+++ b/releng/ru.arsysop.svn.repository/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/releng/ru.arsysop.svn.target/ru.arsysop.svn.target.target
+++ b/releng/ru.arsysop.svn.target/ru.arsysop.svn.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
 <!--
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/ru.arsysop.svn.connector.svnkit1_10.tests/OSGI-INF/l10n/bundle.properties
+++ b/tests/ru.arsysop.svn.connector.svnkit1_10.tests/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/ru.arsysop.svn.connector.svnkit1_10.tests/build.properties
+++ b/tests/ru.arsysop.svn.connector.svnkit1_10.tests/build.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2023, 2024 ArSysOp
+# Copyright (c) 2023, 2025 ArSysOp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/ru.arsysop.svn.connector.svnkit1_10.tests/src/ru/arsysop/svn/internal/connector/svnkit1_10/SvnKit1_10ConnectorFactoryTest.java
+++ b/tests/ru.arsysop.svn.connector.svnkit1_10.tests/src/ru/arsysop/svn/internal/connector/svnkit1_10/SvnKit1_10ConnectorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 ArSysOp
+ * Copyright (c) 2023, 2025 ArSysOp
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* All the headers should be ASL 2.0 (c) ArSysOp 2023, 2025

Fixes #71