### PR TITLE
[#13] Extend CI to publish update-site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Download p2
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: p2
 


### PR DESCRIPTION
* update `actions/download-artifact` to v4