### PR TITLE
[#143] Make subversive plugin dependency version less strict

### DIFF
--- a/bundles/ru.arsysop.svn.connector.svnkit1_10/META-INF/MANIFEST.MF
+++ b/bundles/ru.arsysop.svn.connector.svnkit1_10/META-INF/MANIFEST.MF
@@ -26,6 +26,6 @@ Import-Package: de.regnis.q.sequence.line;version="1.0.4",
  org.tmatesoft.svn.core.javahl17;version="1.10.11",
  org.tmatesoft.svn.util;version="1.10.11"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.18.0",
- org.eclipse.team.svn.core;bundle-version="5.0.0"
+ org.eclipse.team.svn.core;bundle-version="[5.0.0,6.0.0)"
 Bundle-ActivationPolicy: lazy
 Export-Package: sun.security.x509


### PR DESCRIPTION
- changed version constraint to be usable until next major release

Fixes #143 