### PR TITLE
[#148] fix pipline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Echo Maven
       run: echo "MAVEN_OPTS='-Xmx2048m'" > ~/.mavenrc
     - name: Cache maven repo
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       env:
         cache-name: cache-maven-repo
       with:


### PR DESCRIPTION
[cache](https://github.com/actions/cache) v2 looks to be retired, use v4 